### PR TITLE
Correct routes on home page

### DIFF
--- a/frontend/src/components/main/main_page.js
+++ b/frontend/src/components/main/main_page.js
@@ -19,7 +19,7 @@ class MainPage extends React.Component {
     const { randomContent } = this.props;
     if ("quoteText" in randomContent) {
       return (
-        <Link to={`/photos/${randomContent._id}`} key={randomContent._id}>
+        <Link to={`/quotes/${randomContent._id}`} key={randomContent._id}>
           <span className="main-quote">
             <p className="quote-text">"{randomContent.quoteText}" </p>
             <p className="quote-author">-{randomContent.author}</p>


### PR DESCRIPTION
This fixes a bug that showed up on heroku deployment but not locally. The routes were wrong in my initial commit for the home page to show page link